### PR TITLE
`relation()` — Join Invariant for Cross-Sort ADT Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ there is an emphasis on the Bird-Meertens Formalism (BMF) (Squiggol) of making p
   - [Relation Declaration](#relation-declaration)
   - [Auto-Generated Operations](#auto-generated-operations)
   - [Join Invariant (Auto-Generated)](#join-invariant-auto-generated)
+    - [Cross-Sort Variant Fields](#cross-sort-variant-fields)
   - [Logic Programming Interpretation (Relation)](#logic-programming-interpretation-relation)
   - [Complete Example: Ancestor Relation](#complete-example-ancestor-relation)
   - [Cycle Handling](#cycle-handling)
@@ -2935,6 +2936,46 @@ This is the definition of **relational composition** in an allegory: two relatio
 The invariant is what makes `closure()` correct: during fixpoint iteration, it silently rejects invalid compositions (they throw `TypeError` at construction time, which `closure()` catches and skips). Only connected chains survive, so every derived fact represents a valid path through the relation.
 
 You never write this invariant yourself: it is derived from the endpoint projections. If you were using plain `data()`, you would need to write `[invariant]: ({ first, second }) => first.destination === second.origin` by hand on every recursive variant. `relation()` generates it for you.
+
+#### Cross-Sort Variant Fields
+
+With the [sorts-as-types](#cross-sort-field-validation) architecture, a variant's composition fields may reference **another `relation()` ADT** instead of the `family` sentinel. `relation()` recognises these as equivalent to `family` fields and generates the same join invariant automatically.
+
+A typical pattern is to extend a base relation with a composition variant in a child relation:
+
+```ts
+// Base relation: a single hop between string endpoints.
+const Step = relation(family => ({
+    Direct: { from: String, to: String }
+})).ops(({ fold, origin, destination }) => ({
+    [origin]:      fold({ out: String })({ Direct: ({ from }) => from }),
+    [destination]: fold({ out: String })({ Direct: ({ to }) => to })
+}));
+
+// Child relation: extends Step and composes two Step instances.
+// The join invariant `first[destination] === second[origin]` is
+// auto-generated for Multi, exactly as if the fields used `family`.
+const Chain = relation(family => ({
+    [extend]: Step,
+    Multi: { first: Step, second: Step }   // cross-sort composition
+})).ops(({ fold, origin, destination }) => ({
+    [origin]: fold({ out: String })({
+        Direct: ({ from }) => from,
+        // Cross-sort fields are not auto-folded — access the endpoint symbol directly.
+        Multi:  ({ first }) => first[origin]
+    }),
+    [destination]: fold({ out: String })({
+        Direct: ({ to }) => to,
+        Multi:  ({ second }) => second[destination]
+    })
+}));
+```
+
+Two differences from the `family` case are worth noting:
+
+1. **No auto-fold on cross-sort fields.** When a variant field is typed by the `family` sentinel, `fold` handlers receive an already-evaluated recursive result. When a field is typed by another `relation()` ADT, it arrives as the raw ADT instance — you must access `[origin]` or `[destination]` on it explicitly in the fold handler.
+
+2. **`closure()` requires `instanceof` the extended relation.** Base facts passed to `Chain.closure()` must be instances of `Chain`, not the base `Step`. Use `Chain.Direct(...)` (inherited via `[extend]`) rather than `Step.Direct(...)`.
 
 ### Logic Programming Interpretation (Relation)
 

--- a/README.md
+++ b/README.md
@@ -2975,7 +2975,9 @@ Two differences from the `family` case are worth noting:
 
 1. **No auto-fold on cross-sort fields.** When a variant field is typed by the `family` sentinel, `fold` handlers receive an already-evaluated recursive result. When a field is typed by another `relation()` ADT, it arrives as the raw ADT instance — you must access `[origin]` or `[destination]` on it explicitly in the fold handler.
 
-2. **`closure()` requires `instanceof` the extended relation.** Base facts passed to `Chain.closure()` must be instances of `Chain`, not the base `Step`. Use `Chain.Direct(...)` (inherited via `[extend]`) rather than `Step.Direct(...)`.
+2. **`.ops()` must be called before constructing cross-sort values.** `first[origin]` and `second[destination]` work only once the base relation's endpoint symbols have been installed, which happens when `.ops()` is called. If `Step` were used before its `.ops()` chain resolves — for example, as a field spec in a standalone `data()` declaration that constructs instances before `Step.ops(...)` runs — the `[origin]`/`[destination]` getters would be `undefined` on those instances at fold time. In practice this is not an issue when `Step` and `Chain` are declared at module scope in the order shown: `Step` is fully initialised (including `.ops()`) before `Chain` construction begins.
+
+3. **`closure()` requires `instanceof` the extended relation.** Base facts passed to `Chain.closure()` must be instances of `Chain`, not the base `Step`. Use `Chain.Direct(...)` (inherited via `[extend]`) rather than `Step.Direct(...)`.
 
 ### Logic Programming Interpretation (Relation)
 

--- a/src/Relation.mts
+++ b/src/Relation.mts
@@ -22,7 +22,7 @@
 
 import { data, invariant } from './Data.mjs';
 import type { DataFoldFn } from './Data.mjs';
-import { op, spec as specSym, isOperationDef, isFamilyRefSpec, LapisTypeSymbol, assertNotNothing } from './operations.mjs';
+import { op, spec as specSym, isOperationDef, isFamilyRefSpec, LapisTypeSymbol, assertNotNothing, extend as extendSym } from './operations.mjs';
 
 // ---- Internal relation marker -----------------------------------------------
 
@@ -163,6 +163,14 @@ export function relation<D extends Record<string, unknown>>(
         const leafVariants: string[] = [];
         const recursiveVariants: RecursiveVariantInfo[] = [];
 
+        // Cross-sort composition: a field typed by another relation() ADT is
+        // only compositional (family-like) if that ADT is the same as the
+        // [extend] parent or an ancestor of it (i.e. instances of this relation
+        // are also instances of fieldSpec via the prototype chain).  This prevents
+        // unrelated relation ADTs used as metadata fields from being misclassified.
+        const parentRelation = (rawSpec as Record<symbol, unknown>)[extendSym] ?? null;
+
+
         for (const [key, value] of Object.entries(rawSpec)) {
             if (RESERVED.has(key)) {
                 throw new Error(
@@ -187,10 +195,23 @@ export function relation<D extends Record<string, unknown>>(
             const fieldNames = Object.keys(fieldSpec).filter(
                 f => f !== String(invariant) && f !== 'invariant'
             );
-            const familyFields = fieldNames.filter(
-                f => isFamilyRefSpec(fieldSpec[f]) || isRelationFieldMatch(fieldSpec[f]));
-            const nonFamilyFields = fieldNames.filter(
-                f => !isFamilyRefSpec(fieldSpec[f]) && !isRelationFieldMatch(fieldSpec[f]));
+            const isCompositionField = (f: string): boolean => {
+                const fs = fieldSpec[f];
+                if (isFamilyRefSpec(fs)) return true;
+                if (!isRelationFieldMatch(fs)) return false;
+                if (fs === parentRelation) return true;
+                if (!parentRelation) return false;
+                // fieldSpec is an ancestor of parentRelation when
+                // parentRelation.prototype instanceof fieldSpec.
+                try {
+                    return (parentRelation as { prototype: object }).prototype
+                        instanceof (fs as abstract new (...args: unknown[]) => unknown);
+                } catch {
+                    return false;
+                }
+            };
+            const familyFields = fieldNames.filter(isCompositionField);
+            const nonFamilyFields = fieldNames.filter(f => !isCompositionField(f));
 
             if (familyFields.length === 0) {
                 // Leaf constructor — no Self references
@@ -421,7 +442,7 @@ export function relation<D extends Record<string, unknown>>(
     });
 
     (ADT as unknown as Record<symbol, boolean>)[LapisTypeSymbol] = true;
-    (ADT as unknown as Record<symbol, boolean>)[RelationSymbol] = true;
+    Object.defineProperty(ADT, RelationSymbol, { value: true, writable: false, enumerable: false, configurable: true });
     return ADT as unknown as RelationShape<D> & {
         ops<O extends Record<string, unknown>>(
             opsFn: (ctx: RelationOpsContext<D>) => O

--- a/src/Relation.mts
+++ b/src/Relation.mts
@@ -23,6 +23,23 @@
 import { data, invariant } from './Data.mjs';
 import type { DataFoldFn } from './Data.mjs';
 import { op, spec as specSym, isOperationDef, isFamilyRefSpec, LapisTypeSymbol, assertNotNothing } from './operations.mjs';
+
+// ---- Internal relation marker -----------------------------------------------
+
+/** Brands each relation() ADT so cross-sort field references can be detected. */
+const RelationSymbol: unique symbol = Symbol('Relation');
+
+/**
+ * Returns true when `fieldSpec` is a Lapis relation ADT produced by `relation()`.
+ * Used to classify fields typed by another relation as "family-like"
+ * (participants in the join invariant), complementing `isFamilyRefSpec`.
+ */
+function isRelationFieldMatch(fieldSpec: unknown): boolean {
+    return !!fieldSpec &&
+        (typeof fieldSpec === 'object' || typeof fieldSpec === 'function') &&
+        !!(fieldSpec as Record<symbol, unknown>)[LapisTypeSymbol] &&
+        !!(fieldSpec as Record<symbol, unknown>)[RelationSymbol];
+}
 import type { DataDeclParams, DataADTWithParams, DataInstance } from './types.mjs';
 import type { unfold, map, merge } from './operations.mjs';
 
@@ -170,8 +187,10 @@ export function relation<D extends Record<string, unknown>>(
             const fieldNames = Object.keys(fieldSpec).filter(
                 f => f !== String(invariant) && f !== 'invariant'
             );
-            const familyFields = fieldNames.filter(f => isFamilyRefSpec(fieldSpec[f]));
-            const nonFamilyFields = fieldNames.filter(f => !isFamilyRefSpec(fieldSpec[f]));
+            const familyFields = fieldNames.filter(
+                f => isFamilyRefSpec(fieldSpec[f]) || isRelationFieldMatch(fieldSpec[f]));
+            const nonFamilyFields = fieldNames.filter(
+                f => !isFamilyRefSpec(fieldSpec[f]) && !isRelationFieldMatch(fieldSpec[f]));
 
             if (familyFields.length === 0) {
                 // Leaf constructor — no Self references
@@ -212,6 +231,11 @@ export function relation<D extends Record<string, unknown>>(
                 transformed[key] = value;
             }
         }
+
+        // Pass through symbol-keyed entries (e.g. [extend], [satisfies], [sort], [isSort])
+        // Object.entries() above only iterates string keys; symbols must be copied explicitly.
+        for (const sym of Object.getOwnPropertySymbols(rawSpec))
+            transformed[sym] = (rawSpec as Record<symbol, unknown>)[sym];
 
         // Store classification for closure computation
         classification = { leafVariants, recursiveVariants };
@@ -397,6 +421,7 @@ export function relation<D extends Record<string, unknown>>(
     });
 
     (ADT as unknown as Record<symbol, boolean>)[LapisTypeSymbol] = true;
+    (ADT as unknown as Record<symbol, boolean>)[RelationSymbol] = true;
     return ADT as unknown as RelationShape<D> & {
         ops<O extends Record<string, unknown>>(
             opsFn: (ctx: RelationOpsContext<D>) => O

--- a/src/tests/relation-cross-sort.test.mts
+++ b/src/tests/relation-cross-sort.test.mts
@@ -130,3 +130,44 @@ describe('relation cross-sort — AC3c: reachingTo() returns correct origins', (
         assert.deepStrictEqual((result as string[]).sort(), ['a', 'b']);
     });
 });
+
+// ── Regression: unrelated relation ADT as metadata field must not be classified
+// as a composition (family-like) field, and must not trigger join invariant
+// generation or affect closure() behaviour.
+
+describe('relation cross-sort — unrelated relation field treated as leaf metadata', () => {
+    // A completely unrelated relation used only as metadata — e.g. provenance.
+    const Provenance = relation(family => ({
+        Source: { label: String }
+    })).ops(({ fold, origin, destination }) => ({
+        [origin]:      fold({ out: String })({ Source: ({ label }) => label }),
+        [destination]: fold({ out: String })({ Source: ({ label }) => label })
+    }));
+
+    // Annotated: Direct carries a Provenance instance as metadata.
+    // Annotated does NOT extend Provenance, so Provenance must NOT be treated
+    // as a family field — no join invariant should be generated for it.
+    const Annotated = relation(family => ({
+        Direct: { from: String, to: String, prov: Provenance }
+    })).ops(({ fold, origin, destination }) => ({
+        [origin]:      fold({ out: String })({ Direct: ({ from }) => from }),
+        [destination]: fold({ out: String })({ Direct: ({ to }) => to })
+    }));
+
+    test('Direct with prov field constructs without any join invariant restriction', () => {
+        const p = Provenance.Source({ label: 'test' });
+        assert.doesNotThrow(() => Annotated.Direct({ from: 'a', to: 'b', prov: p }));
+    });
+
+    test('Direct is classified as a leaf variant (no composition attempted in closure)', () => {
+        const p = Provenance.Source({ label: 'src' });
+        const baseFacts = [
+            Annotated.Direct({ from: 'a', to: 'b', prov: p }),
+            Annotated.Direct({ from: 'b', to: 'c', prov: p })
+        ];
+        // closure() should return exactly the two base facts — no recursive
+        // variant exists, so no new derivations are attempted.
+        const closed = Annotated.closure(baseFacts);
+        assert.strictEqual(closed.length, 2);
+    });
+});

--- a/src/tests/relation-cross-sort.test.mts
+++ b/src/tests/relation-cross-sort.test.mts
@@ -1,0 +1,132 @@
+/**
+ * Tests for relation() join invariant for cross-sort ADT fields.
+ *
+ * With the sorts-as-types architecture, variant fields may reference
+ * another relation ADT directly (e.g. `first: Step`) instead of using the
+ * `family` sentinel. This file verifies that `relation()` correctly classifies
+ * such fields as "family-like" and auto-generates the join invariant
+ * `first.destination === second.origin`.
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { relation, origin, destination, extend } from '../index.mjs';
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+// Base relation: single-hop step between string endpoints.
+const Step = relation(family => ({
+    Direct: { from: String, to: String }
+})).ops(({ fold, origin, destination }) => ({
+    [origin]: fold({ out: String })({
+        Direct: ({ from }) => from
+    }),
+    [destination]: fold({ out: String })({
+        Direct: ({ to }) => to
+    })
+}));
+
+// Extended relation: composes two Step instances into a multi-hop chain.
+// Multi has two fields typed by Step (a peer relation ADT — not the family
+// sentinel). The join invariant `first[destination] === second[origin]`
+// should be auto-generated.
+const Chain = relation(family => ({
+    [extend]: Step,
+    Multi: { first: Step, second: Step }
+})).ops(({ fold, origin, destination }) => ({
+    [origin]: fold({ out: String })({
+        Direct: ({ from }) => from,
+        // Cross-sort fields are not auto-folded; access the fold result explicitly.
+        Multi:  ({ first }) => (first as Record<symbol, string>)[origin]
+    }),
+    [destination]: fold({ out: String })({
+        Direct: ({ to }) => to,
+        Multi:  ({ second }) => (second as Record<symbol, string>)[destination]
+    })
+}));
+
+// ── AC1 — join invariant enforced: matching endpoints succeed ─────────────────
+
+describe('relation cross-sort — AC1: matching endpoints construct successfully', () => {
+    test('Multi with matching endpoints (first[dest] === second[origin]) constructs without error', () => {
+        const ab = Step.Direct('a', 'b');
+        const bc = Step.Direct('b', 'c');
+        // first[destination] = 'b', second[origin] = 'b' — valid composition
+        assert.doesNotThrow(() => Chain.Multi({ first: ab, second: bc }));
+    });
+
+    test('constructed Multi instance has correct endpoints via origin/destination', () => {
+        const ab = Step.Direct('a', 'b');
+        const bc = Step.Direct('b', 'c');
+        const multi = Chain.Multi({ first: ab, second: bc });
+        assert.strictEqual(multi[origin], 'a');
+        assert.strictEqual(multi[destination], 'c');
+    });
+});
+
+// ── AC2 — join invariant enforced: mismatched endpoints throw TypeError ────────
+
+describe('relation cross-sort — AC2: mismatched endpoints throw TypeError', () => {
+    test('Multi with mismatched endpoints (first[dest] !== second[origin]) throws TypeError', () => {
+        const ab = Step.Direct('a', 'b');
+        const cd = Step.Direct('c', 'd');
+        // first[destination] = 'b', second[origin] = 'c' — invalid composition
+        assert.throws(
+            () => Chain.Multi({ first: ab, second: cd }),
+            TypeError
+        );
+    });
+});
+
+// ── AC3 — closure(), reachableFrom(), reachingTo() work on cross-sort relation ─
+
+describe('relation cross-sort — AC3a: closure() produces correct transitive pairs', () => {
+    test('closure over Direct base facts derives Multi chain facts', () => {
+        // Must use Chain.Direct (not Step.Direct): closure() validates instanceof Chain.
+        const baseFacts = [
+            Chain.Direct({ from: 'a', to: 'b' }),
+            Chain.Direct({ from: 'b', to: 'c' }),
+            Chain.Direct({ from: 'c', to: 'd' })
+        ];
+
+        const closed = Chain.closure(baseFacts);
+
+        const pairs = closed.map((f: unknown) => {
+            const o = (f as Record<symbol, unknown>)[origin] as string;
+            const d = (f as Record<symbol, unknown>)[destination] as string;
+            return `${o}->${d}`;
+        });
+
+        // All direct edges preserved
+        assert.ok(pairs.includes('a->b'), 'missing a->b');
+        assert.ok(pairs.includes('b->c'), 'missing b->c');
+        assert.ok(pairs.includes('c->d'), 'missing c->d');
+        // Transitive composition should be derived
+        assert.ok(pairs.includes('a->c'), 'missing a->c');
+        assert.ok(pairs.includes('b->d'), 'missing b->d');
+        assert.ok(pairs.includes('a->d'), 'missing a->d');
+    });
+});
+
+describe('relation cross-sort — AC3b: reachableFrom() returns correct destinations', () => {
+    test('reachableFrom over closure returns all reachable destinations from origin', () => {
+        const baseFacts = [
+            Chain.Direct({ from: 'a', to: 'b' }),
+            Chain.Direct({ from: 'b', to: 'c' })
+        ];
+        const closed = Chain.closure(baseFacts);
+        const result = Chain.reachableFrom(closed, ['a']);
+        assert.deepStrictEqual((result as string[]).sort(), ['b', 'c']);
+    });
+});
+
+describe('relation cross-sort — AC3c: reachingTo() returns correct origins', () => {
+    test('reachingTo over closure returns all origins that reach a destination', () => {
+        const baseFacts = [
+            Chain.Direct({ from: 'a', to: 'b' }),
+            Chain.Direct({ from: 'b', to: 'c' })
+        ];
+        const closed = Chain.closure(baseFacts);
+        const result = Chain.reachingTo(closed, ['c']);
+        assert.deepStrictEqual((result as string[]).sort(), ['a', 'b']);
+    });
+});


### PR DESCRIPTION
Fixes #199